### PR TITLE
chore(tsconfig): set `lib` to `esnext` explicitly, ditch `esModuleInterop`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "target": "esnext",
+    "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "tsBuildInfoFile": "dist/.tsbuildinfo",
     "skipLibCheck": true,
-    "esModuleInterop": true,
     "verbatimModuleSyntax": true,
     "strict": true,
     "incremental": true,


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Set `lib` to `["esnext"]` to stop leaking DOM types into our Node env.
2. Ditched `esModuleInterop`. Since we're using `moduleResolution: "bundler"`, TS is already chill with imports, so we don't really need this flag.

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->

https://www.typescriptlang.org/tsconfig/#lib
https://www.typescriptlang.org/tsconfig/#esModuleInterop
