### PR TITLE
ci: use `pnpm` instead of `ni` in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install ni
-        run: npm i -g @antfu/ni
+      - name: Enable pnpm
+        run: corepack enable pnpm
       - name: Install dependencies
-        run: nci
-      - name: Build dist
-        run: nr build
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
       - name: Run bundle-analyzer
         # TODO: Waiting for bundle-analyzer to support esbuild.
         # https://github.com/codecov/codecov-javascript-bundler-plugins/issues/41


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
