### PR TITLE
ci: use `pnpm dlx` instead of `npx` in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Run bundle-analyzer
         # TODO: Waiting for bundle-analyzer to support esbuild.
         # https://github.com/codecov/codecov-javascript-bundler-plugins/issues/41
-        run: pnpx @codecov/bundle-analyzer ./dist -c .config/codecov/bundle-analyzer.json
+        run: pnpm dlx @codecov/bundle-analyzer ./dist -c .config/codecov/bundle-analyzer.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Run bundle-analyzer
         # TODO: Waiting for bundle-analyzer to support esbuild.
         # https://github.com/codecov/codecov-javascript-bundler-plugins/issues/41
-        run: npx @codecov/bundle-analyzer ./dist -c .config/codecov/bundle-analyzer.json
+        run: pnpx @codecov/bundle-analyzer ./dist -c .config/codecov/bundle-analyzer.json


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
