### PR TITLE
refactor(run): tighten type safety for `styleTextOptions`

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -12,7 +12,7 @@ import type { SetupToolContext, RunToolContext } from '@/types'
 
 const { isTitleCheckEnabled, pullRequestTitle, eventName } = actionContext
 const limit = pLimit(concurrency)
-const styleTextOptions: StyleTextOptions = { validateStream: false }
+const styleTextOptions = { validateStream: false } as const satisfies StyleTextOptions
 const successIcon = styleText('green', '✔', styleTextOptions)
 const failureIcon = styleText('red', '✖', styleTextOptions)
 


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
