### PR TITLE
chore(linters): remove unnecessary copyright comments in `commitlint`

### DIFF
--- a/src/linters/commitlint.ts
+++ b/src/linters/commitlint.ts
@@ -10,9 +10,6 @@ export async function commitlint(message: string): Promise<void> {
         warnings,
         input,
     } = await lint(message, config.rules, {
-        // https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/parser.js
-        // Copyright © [conventional-changelog team](https://github.com/conventional-changelog)
-        // Distributed under the [ISC License](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/LICENSE.md)
         parserOpts: {
             headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
             breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
