### PR TITLE
ci: adopt `$/` self-repository syntax and silence `actionlint`

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/{audit,check-pull-request-title,lint}.yml:
+    ignore:
+      # TODO: Support the new `$/` self-repository `uses:` syntax.
+      # https://github.com/rhysd/actionlint/issues/711
+      - 'specifying action "\$/" in invalid format.+'

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Insight
-        uses: ./
+        uses: $/

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Insight
-        uses: ./
+        uses: $/
         with:
           check-pull-request-title: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Insight
-        uses: ./
+        uses: $/


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
